### PR TITLE
Allow value to be set undefined if it is explicitly set as default

### DIFF
--- a/src/ejson_decode.erl
+++ b/src/ejson_decode.erl
@@ -77,9 +77,9 @@ extract_fields([Field | F], AttrList, Opts) ->
                 false ->
                     %% No value for field, check if we have default
                     case default_value(Field) of
-                        undefined ->
+                        false ->
                             {error, {no_value_for, Field}};
-                        DefVal ->
+                        {_, DefVal} ->
                             [DefVal | extract_fields(F, AttrList, Opts)]
                     end;
                 {_, Value} ->
@@ -239,6 +239,6 @@ default_value({Type, _, Opts}) when Type =:= atom orelse
                                     Type =:= number orelse
                                     Type =:= record orelse
                                     Type =:= string ->
-    proplists:get_value(default, Opts);
+    lists:keyfind(default, 1, Opts);
 default_value(_) ->
-    undefined.
+    false.

--- a/test/ejson_default.erl
+++ b/test/ejson_default.erl
@@ -7,10 +7,14 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% Test for default value for address
--json({book, {string, "title"}, {list, "authors"}, {number, "year"}}).
+-json({book, {string, "title"}, {list, "authors", [{type, person}]}, {number, "year"}}).
 %% People can be authors
 -json({person, {string, "name"},
                {string, "address", [{default, "No address"}]}}).
+
+-json({planet,
+       {binary, "name"},
+       {number, "population", [{default, undefined}]}}).
 
 default_test_() ->
     B = {book, "Treasure Island", [{person, "Robert Louis Stevenson"}], 1911},
@@ -18,11 +22,23 @@ default_test_() ->
     {ok, Dec} = from_json(Enc, book),
     ?_assertMatch({book, _, [{person, _, undefined}], 1911}, Dec).
 
+default_real_test_() ->
+    Enc = <<"{\"title\":\"Treasure Island\","
+            " \"authors\":[{\"name\":\"Robert Louis Stevenson\"}],"
+            " \"year\":1911}">>,
+    {ok, Dec} = from_json(Enc, book),
+    ?_assertMatch({book, "Treasure Island", [{person, "Robert Louis Stevenson", "No address"}], 1911},
+                  Dec).
+
 default_field_test_() ->
     B = {book, "Treasure Island", [{person, "Robert Louis Stevenson"}], 1911},
     {ok, J} = ejson:to_jsx_modules(B, [?MODULE]),
     ?debugVal(J),
     [?_assertEqual(<<"Treasure Island">>, json_path(J, "title")),
-     ?_assertEqual(<<"person">>, json_path(J, "authors.1.__rec")),
      ?_assertEqual(<<"Robert Louis Stevenson">>, json_path(J, "authors.1.name")),
      ?_assertEqual(null, json_path(J, "authors.1.address"))].
+
+default_undefined_test_() ->
+    Enc = <<"{\"name\":\"Mars\"}">>,
+    {ok, Dec} = from_json(Enc, planet),
+    ?_assertMatch({planet, <<"Mars">>, undefined}, Dec).


### PR DESCRIPTION
We want the default value be exaclty as we specify even if it is atom 'undefined'. This should definitely emit no errors.

Also notice the tests don't test for the default value. The default option is only used when the encoded string doesn't have corresponding attribute, but tests do build this string from records in which cases this value is always filled (with null).

The tests use tuple tagged 'person' which length is not equal to the record length actually. Not sure if this is intentional or a buggy behaviour.