### PR TITLE
Skip undefined values rather then convert them to null if undefined is default

### DIFF
--- a/src/ejson_decode.erl
+++ b/src/ejson_decode.erl
@@ -77,9 +77,9 @@ extract_fields([Field | F], AttrList, Opts) ->
                 false ->
                     %% No value for field, check if we have default
                     case default_value(Field) of
-                        undefined ->
+                        false ->
                             {error, {no_value_for, Field}};
-                        DefVal ->
+                        {_, DefVal} ->
                             [DefVal | extract_fields(F, AttrList, Opts)]
                     end;
                 {_, Value} ->
@@ -239,6 +239,6 @@ default_value({Type, _, Opts}) when Type =:= atom orelse
                                     Type =:= number orelse
                                     Type =:= record orelse
                                     Type =:= string ->
-    proplists:get_value(default, Opts);
+    lists:keyfind(default, 1, Opts);
 default_value(_) ->
-    undefined.
+    false.

--- a/src/ejson_encode.erl
+++ b/src/ejson_encode.erl
@@ -80,7 +80,7 @@ convert([], _Tuple, _Opts, Result) ->
 convert([{Name, Value} | T], Tuple, Opts, Result) ->
     case maybe_pre_process(Name, Tuple, Value) of
         {ok, PreProcessed} ->
-            case apply_rule(Name, PreProcessed, Opts) of
+            case maybe_apply_rule(Name, PreProcessed, Opts) of
                 undefined ->
                     convert(T, Tuple, Opts, Result);
                 {error, _} = Error ->
@@ -97,6 +97,16 @@ convert([{Name, Value} | T], Tuple, Opts, Result) ->
     end.
 
 %% Generate jsx attribute from ejson field
+maybe_apply_rule({_, _, FieldOpts} = Name, undefined = Value, Opts) ->
+    case lists:keyfind(default, 1, FieldOpts) of
+        {_, undefined} ->
+            undefined;
+        _ ->
+            apply_rule(Name, Value, Opts)
+    end;
+maybe_apply_rule(Name, Value, Opts) ->
+    apply_rule(Name, Value, Opts).
+
 apply_rule(Name, Value, Opts) ->
     case Name of
         skip ->

--- a/test/ejson_default.erl
+++ b/test/ejson_default.erl
@@ -42,3 +42,8 @@ default_undefined_test_() ->
     Enc = <<"{\"name\":\"Mars\"}">>,
     {ok, Dec} = from_json(Enc, planet),
     ?_assertMatch({planet, <<"Mars">>, undefined}, Dec).
+
+default_undefined_encode_test_() ->
+    P = {planet, <<"Mars">>, undefined},
+    {ok, Enc} = to_json(P),
+    ?_assertMatch(<<"{\"name\":\"Mars\"}">>, Enc).

--- a/test/ejson_default.erl
+++ b/test/ejson_default.erl
@@ -7,10 +7,14 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% Test for default value for address
--json({book, {string, "title"}, {list, "authors"}, {number, "year"}}).
+-json({book, {string, "title"}, {list, "authors", [{type, person}]}, {number, "year"}}).
 %% People can be authors
 -json({person, {string, "name"},
                {string, "address", [{default, "No address"}]}}).
+
+-json({planet,
+       {binary, "name"},
+       {number, "population", [{default, undefined}]}}).
 
 default_test_() ->
     B = {book, "Treasure Island", [{person, "Robert Louis Stevenson"}], 1911},
@@ -18,11 +22,23 @@ default_test_() ->
     {ok, Dec} = from_json(Enc, book),
     ?_assertMatch({book, _, [{person, _, undefined}], 1911}, Dec).
 
+default_real_test_() ->
+    Enc = <<"{\"title\":\"Treasure Island\","
+            " \"authors\":[{\"name\":\"Robert Louis Stevenson\"}],"
+            " \"year\":1911}">>,
+    {ok, Dec} = from_json(Enc, book),
+    ?_assertMatch({book, "Treasure Island", [{person, "Robert Louis Stevenson", "No address"}], 1911},
+                  Dec).
+
 default_field_test_() ->
     B = {book, "Treasure Island", [{person, "Robert Louis Stevenson"}], 1911},
     {ok, J} = ejson:to_jsx_modules(B, [?MODULE]),
     ?debugVal(J),
     [?_assertEqual(<<"Treasure Island">>, json_path(J, "title")),
-     ?_assertEqual(<<"person">>, json_path(J, "authors.1.__rec")),
      ?_assertEqual(<<"Robert Louis Stevenson">>, json_path(J, "authors.1.name")),
      ?_assertEqual(null, json_path(J, "authors.1.address"))].
+
+default_undefined_test_() ->
+    Enc = <<"{\"name\":\"Mars\"}">>,
+    {ok, Dec} = from_json(Enc, planet),
+    ?_assertMatch({planet, <<"Mars">>, undefined}, Dec).


### PR DESCRIPTION
This is based on https://github.com/jonasrichard/ejson/pull/29

We don't want the `undefined` values in records to be converted to `null` values, but rather just ignored and not put into the resulting json. The `{default, undefined}` option seems a good indicator that this is the expected behaviour, as decoding the save json would produce the original record.