### PR TITLE
Don't conflict with eunit_autoexport parse transform

### DIFF
--- a/test/ejson_autoexports_test.erl
+++ b/test/ejson_autoexports_test.erl
@@ -1,0 +1,10 @@
+-module(ejson_autoexports_test).
+
+-export([to_json/1]).
+
+-compile({parse_transform, eunit_autoexport}).
+-compile({parse_transform, ejson_trans}).
+
+-json({planet,
+       {binary, "name"},
+       {number, "population", [{default, undefined}]}}).


### PR DESCRIPTION
`eunit_autoexports` parse transform adds a definition AFTER {eof, _} form.