### PR TITLE
upgrade to jsx-3.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROJECT 	= ejson
 DEPS 		= jsx
 TEST_DEPS	= proper
 
-dep_jsx_commit 	= v2.9.0
+dep_jsx_commit 	= v3.0.0
 
 COMPILE_FIRST		= ejson_trans
 TEST_COMPILE_FIRST	= ejson_trans_test ejson_ext1 ejson_ext2 ejson_ext3

--- a/src/ejson.erl
+++ b/src/ejson.erl
@@ -100,14 +100,14 @@ from_json_modules(Binary, ModuleList, Record) ->
     from_json(Binary, Record, Rules, Opts).
 
 from_json(Binary, Rules, Opts) ->
-    Decoded = jsx:decode(Binary),
+    Decoded = jsx:decode(Binary, [{return_maps, false}]),
     %% We don't know what can be in the result, so detect it!
     %% It can be primitive value, primitive value list, or list of records
     %% or simple just a record.
     decode_value(Decoded, Rules, Opts).
 
 from_json(Binary, Record, Rules, Opts) ->
-    Decoded = jsx:decode(Binary),
+    Decoded = jsx:decode(Binary, [{return_maps, false}]),
     ejson_decode:decode(Decoded, Record, Rules, Opts).
 
 %%%----------------------------------------------------------------------------

--- a/test/ejson_skip_test.erl
+++ b/test/ejson_skip_test.erl
@@ -17,6 +17,6 @@ skip_test_() ->
     [{"skip works during encoding",
       [?_assertEqual(<<"/index.html">>, json_prop(Json, "path")),
        ?_assertEqual(<<"GET">>, json_prop(Json, "method")),
-       ?_assertEqual(2, length(jsx:decode(Json)))]},
+       ?_assertEqual(2, length(jsx:decode(Json, [{return_maps, false}])))]},
      {"skip default during decoding",
       ?_assertMatch({request, "INFO", "/index.html", undefined, "GET"}, D)}].

--- a/test/ejson_test_util.erl
+++ b/test/ejson_test_util.erl
@@ -6,7 +6,7 @@
 
 -spec json_prop(binary(), string()) -> undefined | term().
 json_prop(Json, PropName) ->
-    jsx_prop(jsx:decode(Json), PropName).
+    jsx_prop(jsx:decode(Json, [{return_maps, false}]), PropName).
 
 -spec jsx_prop(jsx:term(), string()) -> undefined | term().
 jsx_prop(Jsx, PropName) ->
@@ -18,7 +18,7 @@ jsx_prop(Jsx, PropName) ->
     end.
 
 json_path(Json, Path) ->
-    jsx_path(jsx:decode(Json), Path).
+    jsx_path(jsx:decode(Json, [{return_maps, false}]), Path).
 
 %% Simplifies accessing data in jsx terms
 %%   - name             the value of the name field


### PR DESCRIPTION
I'd like to use jsx 3 in my project with ejosn, but jsx 3 uses maps by default